### PR TITLE
fix: enhance preview client recovery mechanism in service worker

### DIFF
--- a/src/__tests__/integrations/server.test.ts
+++ b/src/__tests__/integrations/server.test.ts
@@ -61,6 +61,14 @@ describe("integrations/server", () => {
     expect(a).toBe(b);
   });
 
+  it("gates preview recovery to actual preview clients for same-origin iframes", async () => {
+    const src = await getServiceWorkerSource();
+    expect(src).toMatch(/hasPreviewClientBeenIdentified/);
+    expect(src).toMatch(/if \(client && !hasPreviewClientBeenIdentified\(client\)\)/);
+    expect(src).toMatch(/regular iframes keep/);
+    expect(src).not.toMatch(/refererPod \|\| mayResolveViaClient \|\| clientId/);
+  });
+
   it("serves both hostname-preview bridge assets", async () => {
     expect(DEFAULT_BRIDGE_HTML_PATH).toBe("/__nodepod_bridge__.html");
     expect(DEFAULT_BRIDGE_SCRIPT_PATH).toBe("/__nodepod_bridge__.js");

--- a/static/__sw__.js
+++ b/static/__sw__.js
@@ -945,6 +945,46 @@ function onPortMessage(event, mp) {
 }
 
 // ── Fetch interception ──
+// Worker globals are lost when the browser suspends this service worker.
+// Ask the requesting preview for its baked-in identity instead of guessing
+// from a stripped path shared by several frames or falling through to the host.
+function recoverPreviewClient(client) {
+  if (!client || client.frameType !== "nested") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    let finished = false;
+    const finish = (pod) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      channel.port1.close();
+      channel.port2.close();
+      resolve(pod);
+    };
+    const timer = setTimeout(() => finish(null), 1000);
+    channel.port1.onmessage = (event) => {
+      const pod = event.data;
+      if (
+        !pod ||
+        typeof pod.instanceId !== "string" ||
+        !pod.instanceId ||
+        !Number.isInteger(pod.serverPort) ||
+        pod.serverPort < 1 ||
+        pod.serverPort > 65535
+      ) {
+        finish(null);
+        return;
+      }
+      adoptPreviewClient(client.id, pod);
+      finish(pod);
+    };
+    try {
+      client.postMessage({ type: "nodepod-recover-preview" }, [channel.port2]);
+    } catch {
+      finish(null);
+    }
+  });
+}
 //
 // only proxy when we can positively attribute a request to a pod:
 //   1. explicit /__virtual__/ or /__preview__/ prefix
@@ -1076,7 +1116,7 @@ self.addEventListener("fetch", (event) => {
   if (!isNavigation) {
     const refererPod = refUrl ? lookupPodForClaimedPath(refUrl.pathname) : null;
     const mayResolveViaClient = !refUrl && clientId && pathClaims.size > 0;
-    if (refererPod || mayResolveViaClient) {
+    if (refererPod || mayResolveViaClient || clientId) {
       event.respondWith(
         (async () => {
           let pod = refererPod;
@@ -1091,6 +1131,10 @@ self.addEventListener("fetch", (event) => {
           if (client && client.frameType === "top-level") {
             return fetch(request);
           }
+          // A live iframe remains the authority even if another preview has
+          // since claimed the same stripped route.
+          const recovered = await recoverPreviewClient(client);
+          if (recovered) pod = recovered;
           if (!pod && client && client.url) {
             try {
               const clientPath = stripPreviewPrefix(new URL(client.url).pathname);
@@ -1428,6 +1472,14 @@ function getLocationPatchScript(instanceId, serverPort) {
 
   if (navigator.serviceWorker) {
     navigator.serviceWorker.addEventListener('controllerchange', claimPath);
+    navigator.serviceWorker.addEventListener('message', function(event) {
+      if (event.source !== navigator.serviceWorker.controller ||
+          !event.data || event.data.type !== 'nodepod-recover-preview' ||
+          !event.ports || !event.ports[0]) return;
+      event.ports[0].postMessage(POD);
+      event.ports[0].close();
+      claimPath();
+    });
     // A dedicated preview worker can be terminated by the browser even while
     // its tab remains open. Its MessagePorts are disposable worker-global
     // state, so recover through the bootstrap on the next request instead of

--- a/static/__sw__.js
+++ b/static/__sw__.js
@@ -947,6 +947,22 @@ function onPortMessage(event, mp) {
 // Worker globals are lost when the browser suspends this service worker.
 // Ask the requesting preview for its baked-in identity instead of guessing
 // from a stripped path shared by several frames or falling through to the host.
+function hasPreviewClientBeenIdentified(client) {
+  if (!client || client.frameType !== "nested") return false;
+  if (client.id && previewClients.has(client.id)) return true;
+  if (!client.url) return false;
+  try {
+    const parsed = new URL(client.url);
+    const explicitPreview =
+      matchPreviewOrVirtualPath(parsed.pathname, "preview") ||
+      matchPreviewOrVirtualPath(parsed.pathname, "virtual");
+    if (explicitPreview) return true;
+    const strippedPath = stripPreviewPrefix(parsed.pathname);
+    if (lookupPodForClaimedPath(strippedPath)) return true;
+  } catch {}
+  return false;
+}
+
 function recoverPreviewClient(client) {
   if (!client || client.frameType !== "nested") return Promise.resolve(null);
   return new Promise((resolve) => {
@@ -1130,6 +1146,9 @@ self.addEventListener("fetch", (event) => {
             }
           }
           if (client && client.frameType === "top-level") {
+            return fetch(request);
+          }
+          if (client && !hasPreviewClientBeenIdentified(client)) {
             return fetch(request);
           }
           // A live iframe remains the authority even if another preview has

--- a/static/__sw__.js
+++ b/static/__sw__.js
@@ -944,7 +944,6 @@ function onPortMessage(event, mp) {
   if (msg.type === "keepalive") return;
 }
 
-// ── Fetch interception ──
 // Worker globals are lost when the browser suspends this service worker.
 // Ask the requesting preview for its baked-in identity instead of guessing
 // from a stripped path shared by several frames or falling through to the host.
@@ -985,6 +984,8 @@ function recoverPreviewClient(client) {
     }
   });
 }
+
+// ── Fetch interception ──
 //
 // only proxy when we can positively attribute a request to a pod:
 //   1. explicit /__virtual__/ or /__preview__/ prefix

--- a/tests/browser/clean-preview.spec.ts
+++ b/tests/browser/clean-preview.spec.ts
@@ -16,6 +16,15 @@ async function waitForGuest(page: Page): Promise<void> {
   await heading.waitFor({ state: "visible", timeout: 20_000 });
 }
 
+async function restartServiceWorker(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+    await navigator.serviceWorker.register("/__sw__.js", { scope: "/" });
+    await navigator.serviceWorker.ready;
+  });
+}
+
 test("clean preview works embedded, top-level, on deep links, and after reload", async ({
   page,
   context,
@@ -50,5 +59,33 @@ test("clean preview works embedded, top-level, on deep links, and after reload",
   await waitForGuest(preview);
   await expect(preview.locator("#request-path")).toHaveText(
     "/nested/route?from=browser-test",
+  );
+});
+
+test("preview iframe can recover its client identity after a service worker restart", async ({
+  page,
+  context,
+}) => {
+  await page.goto("/tests/browser/clean-preview.html");
+  await expect(page.locator("#status")).toHaveAttribute("data-ready", "true", {
+    timeout: 30_000,
+  });
+
+  const cleanUrl = (await page.locator("#status").textContent())!;
+  expect(cleanUrl).toMatch(/^http:\/\/pod[\w-]*-3000\.localhost:3333\//);
+
+  const previewPromise = context.waitForEvent("page");
+  await page.locator("#open").click();
+  const preview = await previewPromise;
+  await waitForGuest(preview);
+
+  await restartServiceWorker(preview);
+  await preview.reload();
+  await waitForGuest(preview);
+
+  await preview.goto(`${cleanUrl}nested/route?from=sw-recovery`);
+  await waitForGuest(preview);
+  await expect(preview.locator("#request-path")).toHaveText(
+    "/nested/route?from=sw-recovery",
   );
 });


### PR DESCRIPTION
### Summary

Fixes preview iframe routing after the service worker is suspended or restarted by recovering the iframe’s original pod identity from the page itself instead of guessing from stripped paths.

### What changed
Added a recovery path for nested preview clients when worker globals are lost re-requests the page’s baked-in pod identity via a MessageChannel handshake preserves correct routing for same-origin iframe requests even when path claims are stale or shared
keeps top-level host pages and unrelated routes from being misrouted adds the worker-side recovery listener in the injected location patch

### Why
Previously, after a service worker suspension/restart, nested preview frames could lose their routing context. The worker could then fall back to ambiguous stripped-path matching or host behavior, causing requests to hit the wrong pod or be treated as host traffic.